### PR TITLE
Fixed Class Import

### DIFF
--- a/src/Covid19.php
+++ b/src/Covid19.php
@@ -12,7 +12,7 @@ namespace RakibDevs\Covid19;
  * @since    2021-01-10
  */
 
-use RakibDevs\Covid19\Src\Exceptions\Covid19Exception;
+use RakibDevs\Covid19\Exceptions\Covid19Exception;
 use Illuminate\Support\Facades\Config;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ClientException;


### PR DESCRIPTION
Throwing a new exception (in the case of not providing a key, as an example) will cause an error since the class is not properly imported.